### PR TITLE
Add AnomFIN maintenance savings calculator tool

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -471,6 +471,124 @@ p {
     color: rgba(255, 255, 255, 0.85);
 }
 
+.calculator {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2.5rem;
+    align-items: start;
+}
+
+.calculator__form,
+.calculator__results {
+    border-radius: var(--radius-lg);
+    padding: 2.5rem;
+    background: rgba(10, 18, 30, 0.45);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 25px 60px rgba(11, 27, 43, 0.25);
+    backdrop-filter: blur(8px);
+}
+
+.calculator__form {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.calculator__fields {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field {
+    display: grid;
+    gap: 0.6rem;
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.95rem;
+}
+
+.field input {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--color-white);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus {
+    outline: none;
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 3px rgba(255, 183, 3, 0.25);
+}
+
+.field input::placeholder {
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.calculator__helper {
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.9rem;
+}
+
+.calculator__submit {
+    justify-self: start;
+}
+
+.calculator__results {
+    display: grid;
+    gap: 1.25rem;
+    color: var(--color-white);
+}
+
+.calculator__results h3 {
+    font-size: 1.4rem;
+}
+
+.calculator__results ul {
+    list-style: none;
+    display: grid;
+    gap: 1rem;
+}
+
+.calculator__results li {
+    display: grid;
+    gap: 0.25rem;
+}
+
+.calculator__results li span {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.calculator__results strong {
+    font-size: 1.3rem;
+    color: var(--color-primary);
+}
+
+.calculator__placeholder {
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.calculator__hint {
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.9rem;
+}
+
+.calculator__signature {
+    margin-top: 2.5rem;
+    text-align: center;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.75);
+    text-transform: uppercase;
+}
+
 .contact {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -646,6 +764,11 @@ p {
 
     .section {
         padding: 4rem 1.25rem;
+    }
+
+    .calculator__form,
+    .calculator__results {
+        padding: 2rem;
     }
 
     .contact__form {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -69,3 +69,55 @@ window.addEventListener('resize', () => {
         navToggle?.classList.remove('nav__toggle--active');
     }
 });
+
+const calculatorForm = document.getElementById('savings-calculator');
+const calculatorResult = document.getElementById('savings-result');
+
+const formatCurrency = (value) =>
+    new Intl.NumberFormat('fi-FI', {
+        style: 'currency',
+        currency: 'EUR',
+        maximumFractionDigits: 0,
+    }).format(Math.round(value));
+
+const formatHours = (value) =>
+    new Intl.NumberFormat('fi-FI', {
+        maximumFractionDigits: value < 10 ? 1 : 0,
+    }).format(value);
+
+calculatorForm?.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(calculatorForm);
+    const machines = Number(formData.get('machines'));
+    const downtime = Number(formData.get('downtime'));
+    const hourlyCost = Number(formData.get('hourlyCost'));
+    const prevented = Number(formData.get('prevented'));
+
+    if ([machines, downtime, hourlyCost, prevented].some((value) => Number.isNaN(value) || value < 0)) {
+        calculatorResult.innerHTML =
+            '<p class="calculator__placeholder">Tarkista syötetyt arvot. Kaikkien lukujen tulee olla positiivisia.</p>';
+        return;
+    }
+
+    const effectiveness = Math.min(Math.max(prevented, 0), 100) / 100;
+    const regainedHours = machines * downtime * effectiveness;
+    const monthlySavings = regainedHours * hourlyCost;
+    const annualSavings = monthlySavings * 12;
+
+    if (monthlySavings <= 0) {
+        calculatorResult.innerHTML =
+            '<p class="calculator__placeholder">Lisää ennakoivan kunnossapidon vaikutusta nähdäksesi säästöt. AnomFIN • AnomTools auttaa mitoittamaan tavoitteet.</p>';
+        return;
+    }
+
+    calculatorResult.innerHTML = `
+        <h3>Arvio säästöistä</h3>
+        <p>Ennakoiva kunnossapito voi palauttaa <strong>${formatHours(regainedHours)}</strong> tuotantotuntia kuukausittain.</p>
+        <ul>
+            <li><span>Kuukausittainen hyöty</span><strong>${formatCurrency(monthlySavings)}</strong></li>
+            <li><span>Vuosittainen hyöty</span><strong>${formatCurrency(annualSavings)}</strong></li>
+        </ul>
+        <p class="calculator__hint">Arvio perustuu AnomFIN • AnomTools tilannehuollon datamalliin. Räätälöidyt laskelmat saat kattavan kuntokartoituksen yhteydessä.</p>
+    `;
+});

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
                 <li><a href="#vuokraus">Vuokraus</a></li>
                 <li><a href="#myynti">Myynti</a></li>
                 <li><a href="#referenssit">Referenssit</a></li>
+                <li><a href="#laskuri">Laskuri</a></li>
                 <li><a href="#yhteys">Yhteys</a></li>
             </ul>
         </nav>
@@ -213,6 +214,42 @@
             </div>
         </section>
 
+        <section class="section section--accent" id="laskuri">
+            <div class="section__intro">
+                <span class="kicker kicker--light">Työkalut</span>
+                <h2>AnomFIN Huoltosäästölaskuri</h2>
+                <p>Arvioi ennakoivan kunnossapidon vaikutus käyttökustannuksiin. AnomTools-analytiikkamme yhdistää kalustosi vikahistorian ja käyttöasteen, jotta tiedät kuinka paljon seisokkiaikaa voidaan poistaa.</p>
+            </div>
+            <div class="calculator">
+                <form class="calculator__form" id="savings-calculator" aria-describedby="savings-helper">
+                    <div class="calculator__fields">
+                        <label class="field">
+                            <span>Koneiden määrä</span>
+                            <input type="number" name="machines" id="machines" min="1" step="1" required placeholder="Esim. 12">
+                        </label>
+                        <label class="field">
+                            <span>Nykyinen seisokkiaika / kone / kk (h)</span>
+                            <input type="number" name="downtime" id="downtime" min="0" step="0.5" required placeholder="Esim. 6">
+                        </label>
+                        <label class="field">
+                            <span>Seisokkikustannus tunnilta (€)</span>
+                            <input type="number" name="hourlyCost" id="hourlyCost" min="0" step="10" required placeholder="Esim. 180">
+                        </label>
+                        <label class="field">
+                            <span>Arvioitu seisokin vähennys (%)</span>
+                            <input type="number" name="prevented" id="prevented" min="0" max="100" step="5" required placeholder="Esim. 35">
+                        </label>
+                    </div>
+                    <p class="calculator__helper" id="savings-helper">Tarkempi analyysi on saatavilla osana AnomFIN • AnomTools kunnonvalvontapalvelua.</p>
+                    <button type="submit" class="btn btn--primary calculator__submit">Laske säästöpotentiaali</button>
+                </form>
+                <div class="calculator__results" id="savings-result" aria-live="polite">
+                    <p class="calculator__placeholder">Syötä luvut ja näet välittömän arvion rahallisista ja ajallisista säästöistä.</p>
+                </div>
+            </div>
+            <p class="calculator__signature" aria-label="Laskelman tuottaja">AnomFIN • AnomTools</p>
+        </section>
+
         <section class="section section--accent" aria-label="Nopeat faktat Harjun Raskaskone Oy:stä">
             <div class="facts">
                 <div>
@@ -305,6 +342,7 @@
                 <h4>Yritys</h4>
                 <ul>
                     <li><a href="#referenssit">Referenssit</a></li>
+                    <li><a href="#laskuri">Laskuri</a></li>
                     <li><a href="#yhteys">Yhteydenotto</a></li>
                     <li><a href="#etusivu">Etusivu</a></li>
                 </ul>


### PR DESCRIPTION
## Summary
- add a dedicated AnomFIN Huoltosäästölaskuri section and navigation link to highlight predictive maintenance value
- style the new calculator layout for dark accent sections and add the required AnomFIN • AnomTools signature messaging
- implement client-side logic to estimate monthly and annual downtime savings for entered fleet metrics

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d72c4ba0908332aeaefbe31623a8a5