### PR TITLE
Add animated hero experience and ecommerce destination

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -17,6 +17,8 @@
     --color-glass: rgba(255, 255, 255, 0.72);
     --shadow-xl: 0 40px 80px rgba(4, 19, 31, 0.24);
     --transition-snappy: cubic-bezier(0.22, 1, 0.36, 1);
+    --cta-gradient: linear-gradient(135deg, #2dd4bf 0%, #0ea5e9 100%);
+    --cta-shadow: 0 40px 80px rgba(15, 118, 110, 0.35);
 }
 
 * {
@@ -34,6 +36,35 @@ body {
     color: var(--color-dark);
     background-color: var(--color-white);
     line-height: 1.6;
+}
+
+body.is-preload {
+    overflow-x: hidden;
+}
+
+body.is-preload .nav,
+body.is-preload .hero,
+body.is-preload .floating-cta,
+body.is-preload [data-floating-origin] {
+    opacity: 0;
+    transform: translateY(48px);
+}
+
+body.is-ready .nav {
+    animation: fadeDown 1.6s var(--transition-snappy) forwards;
+}
+
+body.is-ready .hero__content,
+body.is-ready .hero__image {
+    animation: fadeUp 1.8s var(--transition-snappy) forwards;
+}
+
+body.is-ready .floating-cta {
+    animation: ctaEnter 2.2s ease forwards, ctaDrift 6s ease-in-out infinite 2.4s;
+}
+
+body.is-ready .hero__elevator {
+    animation: elevatorPop 2.4s ease-out forwards, elevatorGlow 3.5s ease-in-out infinite 2.6s;
 }
 
 a {
@@ -58,6 +89,17 @@ h1, h2, h3, h4 {
     color: var(--color-dark);
 }
 
+[data-reveal] {
+    opacity: 0;
+    transform: translateY(60px);
+    transition: opacity 0.9s var(--transition-snappy), transform 0.9s var(--transition-snappy);
+}
+
+[data-reveal].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
 h1 {
     font-size: clamp(2.2rem, 4vw, 3.6rem);
 }
@@ -73,6 +115,13 @@ h3 {
 p {
     font-size: 1.05rem;
     color: var(--color-muted);
+}
+
+section,
+header,
+.feature,
+.sales-card {
+    scroll-margin-top: 120px;
 }
 
 .section {
@@ -198,6 +247,12 @@ p {
     transform: translateY(-3px);
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(229, 248, 244, 0.92));
     box-shadow: 0 26px 48px rgba(4, 19, 31, 0.22);
+}
+
+.nav__link--active {
+    color: var(--color-primary-dark);
+    box-shadow: inset 0 0 0 1px rgba(45, 212, 191, 0.35), 0 18px 32px rgba(45, 212, 191, 0.26);
+    background: rgba(232, 252, 248, 0.85);
 }
 
 .nav__toggle {
@@ -377,60 +432,141 @@ p {
 
 .hero__image {
     position: relative;
-    padding-top: 4rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    z-index: 2;
+    display: grid;
+    align-content: start;
+    gap: 1.5rem;
 }
 
-.hero__image img {
+.hero__panel {
     position: relative;
-    width: clamp(320px, 58vw, 540px);
-    border-radius: calc(var(--radius-lg) + 8px);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
     box-shadow: var(--shadow-xl);
-    transform: translateY(-40px);
-    border: 1px solid rgba(255, 255, 255, 0.55);
+}
+
+.hero__panel img {
+    width: 100%;
+    height: 100%;
     object-fit: cover;
-    z-index: 1;
 }
 
-.hero__image::before {
-    content: "";
+.hero__panel-caption {
     position: absolute;
-    bottom: 6%;
-    width: 70%;
-    height: 60%;
-    border-radius: 50%;
-    background: radial-gradient(circle at 50% 50%, rgba(45, 212, 191, 0.4), transparent 65%);
-    filter: blur(28px);
-    z-index: 0;
-}
-
-.hero__image-chip {
-    position: absolute;
-    right: 8%;
-    bottom: 12%;
+    inset: auto 1.5rem 1.5rem;
     display: inline-flex;
     flex-direction: column;
-    align-items: flex-start;
     gap: 0.35rem;
-    padding: 0.9rem 1.1rem;
-    border-radius: var(--radius-sm);
-    background: rgba(2, 8, 23, 0.82);
-    color: #ecfeff;
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
-    font-size: 0.72rem;
+    background: rgba(4, 19, 31, 0.82);
+    color: var(--color-white);
+    padding: 1rem 1.4rem;
+    border-radius: 18px;
     font-weight: 600;
-    box-shadow: 0 28px 48px rgba(2, 8, 23, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.16);
-    z-index: 1;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    box-shadow: 0 18px 36px rgba(4, 19, 31, 0.35);
 }
 
-.hero__image-chip span:last-child {
-    font-size: 0.78rem;
-    color: var(--color-primary);
-    letter-spacing: 0.24em;
+.hero__elevator {
+    position: sticky;
+    top: 120px;
+    align-self: start;
+    display: grid;
+    place-items: center;
+    text-align: center;
+    padding: 2.75rem 2.25rem;
+    border-radius: var(--radius-lg);
+    background: var(--cta-gradient);
+    color: #022c22;
+    text-transform: uppercase;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    box-shadow: var(--cta-shadow);
+    overflow: hidden;
+    transform-origin: center;
+    transform: translateY(var(--elevator-scroll-offset, 0px));
+}
+
+.hero__elevator strong {
+    display: block;
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.hero__elevator-glow {
+    position: absolute;
+    inset: -30% -20%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0) 65%);
+    filter: blur(12px);
+    opacity: 0.6;
+    pointer-events: none;
+    animation: glowSpin 8s linear infinite;
+}
+
+.hero__elevator-text {
+    position: relative;
+    z-index: 1;
+    font-size: clamp(1.1rem, 2.8vw, 1.35rem);
+    line-height: 1.4;
+}
+
+.hero__elevator-tag {
+    position: relative;
+    z-index: 1;
+    margin-top: 1.8rem;
+    font-size: 0.82rem;
+    letter-spacing: 0.2em;
+    color: rgba(2, 44, 34, 0.75);
+}
+
+.floating-cta {
+    position: fixed;
+    right: clamp(1rem, 4vw, 2.5rem);
+    bottom: clamp(1rem, 4vw, 2.5rem);
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding: 1.5rem 2.2rem;
+    border-radius: 28px;
+    background: rgba(2, 8, 23, 0.92);
+    color: var(--color-white);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-weight: 600;
+    box-shadow: 0 30px 60px rgba(2, 8, 23, 0.45);
+    overflow: hidden;
+    transition: transform 0.5s var(--transition-snappy), box-shadow 0.5s var(--transition-snappy);
+    z-index: 999;
+    transform: translateY(var(--cta-scroll-offset, 0px));
+}
+
+.floating-cta__label {
+    font-size: 0.68rem;
+    color: rgba(255, 255, 255, 0.72);
+    letter-spacing: 0.28em;
+}
+
+.floating-cta__title {
+    font-size: 1.05rem;
+    letter-spacing: 0.16em;
+}
+
+.floating-cta__signature {
+    font-size: 0.7rem;
+    color: rgba(45, 212, 191, 0.85);
+}
+
+.floating-cta__pulse {
+    position: absolute;
+    inset: -120%;
+    background: radial-gradient(circle, rgba(45, 212, 191, 0.28) 0%, rgba(45, 212, 191, 0) 65%);
+    animation: pulse 6s ease-in-out infinite;
+    pointer-events: none;
+}
+
+.floating-cta:hover,
+.floating-cta:focus {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: 0 40px 90px rgba(2, 8, 23, 0.55);
 }
 
 .btn {
@@ -456,6 +592,12 @@ p {
     box-shadow: 0 16px 36px rgba(15, 118, 110, 0.35);
 }
 
+.btn--xl {
+    padding: 0.95rem 2.8rem;
+    font-size: 1.05rem;
+    box-shadow: 0 24px 48px rgba(4, 19, 31, 0.22);
+}
+
 .btn--ghost {
     border: 1px solid rgba(15, 118, 110, 0.3);
     color: var(--color-dark);
@@ -476,6 +618,35 @@ p {
 .btn--secondary:hover {
     background: rgba(45, 212, 191, 0.3);
     transform: translateY(-1px);
+}
+
+.btn--store {
+    position: relative;
+    padding: 1.05rem 3.2rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--color-dark);
+    background: #ffffff;
+    border-radius: 999px;
+    border: 0;
+    box-shadow: 0 26px 60px rgba(14, 165, 233, 0.28);
+    transition: transform 0.6s var(--transition-snappy), box-shadow 0.6s var(--transition-snappy);
+}
+
+.btn--store::after {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border-radius: 999px;
+    border: 2px solid rgba(14, 165, 233, 0.45);
+    pointer-events: none;
+}
+
+.btn--store:hover,
+.btn--store:focus {
+    transform: translateY(-4px) scale(1.03);
+    box-shadow: 0 38px 80px rgba(14, 165, 233, 0.35);
 }
 
 .grid {
@@ -513,6 +684,61 @@ p {
     display: flex;
     flex-direction: column;
     gap: 1rem;
+}
+
+.feature-rows {
+    display: grid;
+    gap: 3.5rem;
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+.feature {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+}
+
+.feature--reverse {
+    direction: rtl;
+}
+
+.feature--reverse > * {
+    direction: ltr;
+}
+
+.feature__media img {
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-xl);
+}
+
+.feature__body ul {
+    margin-top: 1.25rem;
+    display: grid;
+    gap: 0.65rem;
+}
+
+.sales-grid {
+    display: grid;
+    gap: 2.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    max-width: var(--max-width);
+    margin: 0 auto;
+}
+
+.sales-card {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-lg);
+    padding: 2.5rem 2.25rem;
+    box-shadow: var(--shadow-xl);
+    display: grid;
+    gap: 1.25rem;
+}
+
+.sales-card ul {
+    display: grid;
+    gap: 0.6rem;
 }
 
 .card ul,
@@ -694,6 +920,16 @@ p {
 
 .testimonials {
     max-width: var(--max-width);
+    position: relative;
+}
+
+.testimonials::before {
+    content: '';
+    position: absolute;
+    inset: -20% -10%;
+    background: radial-gradient(circle, rgba(45, 212, 191, 0.15) 0%, transparent 60%);
+    filter: blur(20px);
+    z-index: -1;
 }
 
 .testimonial {
@@ -1045,8 +1281,10 @@ p {
         padding-top: 2rem;
     }
 
-    .hero__image img {
-        transform: translateY(-20px);
+    .hero__elevator {
+        position: relative;
+        top: auto;
+        margin-top: 1.5rem;
     }
 }
 
@@ -1060,8 +1298,12 @@ p {
         align-items: stretch;
     }
 
-    .hero__image img {
-        transform: translateY(0);
+    .floating-cta {
+        right: 1rem;
+        left: 1rem;
+        bottom: 1rem;
+        align-items: center;
+        text-align: center;
     }
 
     .hero__stats {
@@ -1083,6 +1325,102 @@ p {
 
     .footer__links {
         margin: 2.5rem 0;
+    }
+}
+
+@keyframes fadeUp {
+    0% {
+        opacity: 0;
+        transform: translateY(60px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes fadeDown {
+    0% {
+        opacity: 0;
+        transform: translateY(-60px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes ctaEnter {
+    0% {
+        opacity: 0;
+        transform: translateY(calc(var(--cta-scroll-offset, 0px) + 50px)) scale(0.9);
+    }
+    60% {
+        opacity: 1;
+        transform: translateY(calc(var(--cta-scroll-offset, 0px) - 12px)) scale(1.04);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(var(--cta-scroll-offset, 0px)) scale(1);
+    }
+}
+
+@keyframes ctaDrift {
+    0%,
+    100% {
+        transform: translateY(var(--cta-scroll-offset, 0px)) scale(1);
+    }
+    50% {
+        transform: translateY(calc(var(--cta-scroll-offset, 0px) - 6px)) scale(1.015);
+    }
+}
+
+@keyframes elevatorPop {
+    0% {
+        opacity: 0;
+        transform: translateY(calc(var(--elevator-scroll-offset, 0px) + 40px)) scale(0.85);
+    }
+    55% {
+        opacity: 1;
+        transform: translateY(calc(var(--elevator-scroll-offset, 0px) - 10px)) scale(1.05);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(var(--elevator-scroll-offset, 0px)) scale(1);
+    }
+}
+
+@keyframes elevatorGlow {
+    0%,
+    100% {
+        box-shadow: var(--cta-shadow);
+    }
+    50% {
+        box-shadow: 0 55px 110px rgba(14, 165, 233, 0.45);
+    }
+}
+
+@keyframes glowSpin {
+    0% {
+        transform: rotate(0deg) scale(1);
+    }
+    100% {
+        transform: rotate(360deg) scale(1.08);
+    }
+}
+
+@keyframes pulse {
+    0% {
+        transform: scale(0.8);
+        opacity: 0.45;
+    }
+    50% {
+        transform: scale(1.05);
+        opacity: 0.75;
+    }
+    100% {
+        transform: scale(0.8);
+        opacity: 0.45;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body>
-    <header class="hero" id="etusivu">
+<body class="is-preload">
+    <header class="hero" id="etusivu" data-reveal>
         <nav class="nav">
             <div class="nav__logo">Helsinki eBike-Service Oy</div>
             <button class="nav__toggle" type="button" aria-label="Avaa valikko" aria-controls="nav-menu" aria-expanded="false">
@@ -20,16 +20,16 @@
                 <span></span>
             </button>
             <ul class="nav__links" id="nav-menu">
-                <li><a class="nav__link" href="#palvelut">Palvelut</a></li>
-                <li><a class="nav__link" href="#vuokraus">Vuokraus</a></li>
-                <li><a class="nav__link" href="#myynti">Myynti</a></li>
-                <li><a class="nav__link" href="#referenssit">Referenssit</a></li>
-                <li><a class="nav__link" href="#laskuri">Laskuri</a></li>
-                <li><a class="nav__link" href="#yhteys">Yhteys</a></li>
+                <li><a class="nav__link" href="#palvelut" data-scroll="palvelut">Palvelut</a></li>
+                <li><a class="nav__link" href="#vuokraus" data-scroll="vuokraus">Vuokraus</a></li>
+                <li><a class="nav__link" href="#myynti" data-scroll="myynti">Myynti</a></li>
+                <li><a class="nav__link" href="#referenssit" data-scroll="referenssit">Referenssit</a></li>
+                <li><a class="nav__link" href="#laskuri" data-scroll="laskuri">Laskuri</a></li>
+                <li><a class="nav__link" href="#yhteys" data-scroll="yhteys">Yhteys</a></li>
                 <li class="nav__cart">
-                    <a class="nav__link nav__link--cart" href="#verkkokauppa" aria-label="Siirry ostoskoriin">
-                        <span>Ostoskori</span>
-                        <span class="nav__cart-count" data-cart-count aria-live="polite">0</span>
+                    <a class="nav__link nav__link--cart" href="verkkokauppa.html" aria-label="Siirry verkkokauppaan">
+                        <span>Verkkokauppa</span>
+                        <span class="nav__cart-count" aria-hidden="true">⇢</span>
                     </a>
                 </li>
             </ul>
@@ -40,8 +40,8 @@
             <h1>Helsinki eBike-Service Oy pitää sähköpyöräsi liikkeessä vuodenaikaan katsomatta</h1>
             <p class="hero__lead">Tarjoamme täyden palvelun sähköpyörähuollon, ammattimaiset yritysratkaisut sekä inspiroivan verkkokaupan, josta löydät laadukkaat pyörät, varaosat ja varusteet. Fiksu yhdistelmä huoltoa, palvelusopimuksia ja joustavaa verkkokauppaa tekee meistä sähköpyöräyritysten ja -harrastajien luotetun kumppanin.</p>
             <div class="hero__actions">
-                <a class="btn btn--primary" href="#yhteys">Varaa huolto</a>
-                <a class="btn btn--ghost" href="#verkkokauppa">Tutustu verkkokauppaan</a>
+                <a class="btn btn--primary btn--xl" href="#yhteys">Varaa huolto</a>
+                <a class="btn btn--store" href="verkkokauppa.html">Tutustu verkkokauppaan</a>
             </div>
             <p class="hero__signature">Jugi@AnomFIN curated • Premium EV cycling studio</p>
             <dl class="hero__stats">
@@ -59,17 +59,31 @@
                 </div>
             </dl>
         </div>
-        <div class="hero__image">
-            <img src="assets/ebikewp.webp" alt="Sähköpyörä huollossa modernissa pyöräpajassa" loading="lazy">
-            <div class="hero__image-chip" aria-hidden="true">
-                <span>Precision tuning</span>
-                <span>Jugi@AnomFIN</span>
+        <div class="hero__image" data-reveal>
+            <div class="hero__panel">
+                <img src="assets/ebikewp.webp" alt="Sähköpyörä huollossa modernissa pyöräpajassa" loading="lazy">
+                <div class="hero__panel-caption">
+                    <span>Precision tuning</span>
+                    <span>Jugi@AnomFIN</span>
+                </div>
             </div>
+            <a class="hero__elevator" href="verkkokauppa.html" aria-label="Tervetuloa verkkokauppaan" data-floating-origin>
+                <span class="hero__elevator-glow"></span>
+                <span class="hero__elevator-text">TERVETULOA<br><strong>VERKKOKAUPPAAN!</strong></span>
+                <span class="hero__elevator-tag">AnomFIN Selection</span>
+            </a>
         </div>
     </header>
 
+    <a class="floating-cta" href="verkkokauppa.html" data-floating-cta>
+        <span class="floating-cta__pulse" aria-hidden="true"></span>
+        <span class="floating-cta__label">Eksklusiivinen sähköpyörävalikoima</span>
+        <span class="floating-cta__title">Siirry verkkokauppaan</span>
+        <span class="floating-cta__signature">Jugi@AnomFIN curated drop</span>
+    </a>
+
     <main>
-        <section class="section section--light" id="palvelut">
+        <section class="section section--light" id="palvelut" data-reveal>
             <div class="section__intro">
                 <span class="kicker">Palvelumme</span>
                 <h2>Huippuluokan sähköpyörähuolto yhdellä käynnillä</h2>
@@ -89,7 +103,7 @@
                     </div>
                 </article>
                 <article class="card">
-                    <img src="https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=1200&q=80" alt="Sähköpyörien vuokrauskalusto rivissä" loading="lazy">
+                    <img src="assets/ebike_web.png" alt="Sähköpyöriä rivissä vuokrauspisteellä" loading="lazy">
                     <div class="card__content">
                         <h3>Vuokraus ja testiajot</h3>
                         <p>Moderni valikoima sähköpyöriä yritystapahtumiin, koeajoihin ja kausivuokraukseen. Räätälöimme paketit tarpeesi mukaan.</p>
@@ -101,21 +115,96 @@
                     </div>
                 </article>
                 <article class="card">
-                    <img src="https://images.unsplash.com/photo-1529429617124-aee711a0fb7c?auto=format&fit=crop&w=1200&q=80" alt="Asiantuntija konsultoi yritystä sähköpyöräohjelmassa" loading="lazy">
+                    <img src="assets/ebike_web2.png" alt="Asiantuntijat suunnittelevat sähköpyörien ostoja" loading="lazy">
                     <div class="card__content">
-                        <h3>Konsultointi &amp; koulutus</h3>
-                        <p>Autamme yrityksiä käynnistämään sähköpyöräpalvelut. Tarjoamme henkilöstön koulutukset ja jatkuvan kunnossapitomallin.</p>
+                        <h3>Huolto, myynti &amp; vaihto</h3>
+                        <p>Rakennamme elinkaarimallit, joissa sähköpyörien osto, vaihto ja jälleenmyynti hoituvat yhdellä kumppanilla. Saat kattavan palveluhistorian digitaalisesti.</p>
                         <ul>
-                            <li>Fleet management -suunnittelu</li>
-                            <li>Työsuhdepyöräohjelmat</li>
-                            <li>Käyttökoulutukset ja webinaarit</li>
+                            <li>Sertifioidut kuntoarviot ennen kauppoja</li>
+                            <li>Nopea jälleenostopalvelu</li>
+                            <li>Premium- ja custom-rungot</li>
                         </ul>
                     </div>
                 </article>
             </div>
         </section>
 
-        <section class="section" id="paketit">
+        <section class="section" id="vuokraus" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Vuokraus &amp; testit</span>
+                <h2>Liikkuvuuspalvelut, jotka seuraavat yrityksesi sykettä</h2>
+                <p>Helsinki eBike-Service Oy:n vuokrauskonsepti tuo toimituksiin ja tapahtumiin helposti skaalautuvan sähköpyörälaivaston. Räätälöity onboarding, vakuutukset ja huoltosopimukset pitävät kaluston ajokunnossa ympäri vuoden.</p>
+            </div>
+            <div class="feature-rows">
+                <article class="feature">
+                    <div class="feature__media">
+                        <img src="assets/ebike_web.png" alt="Vuokrasähköpyörät valmiina toimitukseen" loading="lazy">
+                    </div>
+                    <div class="feature__body">
+                        <h3>Premium-vuokraus 48h toimituksella</h3>
+                        <p>Tarjoamme koeajokaluston ja pitkäaikaisvuokraukset 48 tunnin toimitusikkunalla. Kaikki pyörät tarkastetaan AnomFIN Pro -checklistillä ennen jokaista luovutusta.</p>
+                        <ul>
+                            <li>Logistiikkatiimille omistettu yhteyshenkilö</li>
+                            <li>GPS-seuranta ja akkuvalvonta sisältyvät</li>
+                            <li>Sesonkibundle kampanjat kaupunkitapahtumiin</li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="feature feature--reverse">
+                    <div class="feature__media">
+                        <img src="assets/ebikewp.webp" alt="Huoltoasiantuntija suorittaa vuokrafleetin tarkistusta" loading="lazy">
+                    </div>
+                    <div class="feature__body">
+                        <h3>AnomFIN FleetCare</h3>
+                        <p>FleetCare-ylläpito seuraa pyöriä etänä ja reagoi ennen kuin seisokit syntyvät. Sovi kuukausittaiset huoltokierrot ja vapauta tiimisi keskittymään toimituksiin.</p>
+                        <ul>
+                            <li>Ennakoivat huoltoraportit ja datanäkyvyys</li>
+                            <li>Varapyörät toimitetaan samalla reitillä</li>
+                            <li>Skaalaa helposti 10–500 pyörän kokonaisuuksiin</li>
+                        </ul>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--light" id="myynti" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Myynti &amp; hankinnat</span>
+                <h2>Kuratoitu sähköpyörävalikoima yrityksille ja harrastajille</h2>
+                <p>Autamme rakentamaan juuri oikean sähköpyöräkokoonpanon tiimillesi. Saat käyttöösi testirungot, konsultoinnin ja AnomFINin premium-hankintakanavat.</p>
+            </div>
+            <div class="sales-grid">
+                <article class="sales-card">
+                    <h3>Projektimyynti</h3>
+                    <p>Laadimme koko toimitusketjun rungon valinnasta varusteisiin. Henkilökohtainen asiantuntija varmistaa yhteensopivuuden ja toimitusaikataulut.</p>
+                    <ul>
+                        <li>Curated selection by AnomFIN</li>
+                        <li>Custom branding &amp; wrap-palvelut</li>
+                        <li>Dataohjattu sopimusmalli</li>
+                    </ul>
+                </article>
+                <article class="sales-card">
+                    <h3>Työsuhdepyörä-ohjelmat</h3>
+                    <p>Suunnittelemme yrityksesi työsuhdepyöräpolitiikan ja yhdistämme siihen huoltosopimuksen sekä vakuutukset.</p>
+                    <ul>
+                        <li>Automatisoidut työntekijäportaalit</li>
+                        <li>Yhden luukun huoltopalvelu</li>
+                        <li>Raportointi taloushallinnolle</li>
+                    </ul>
+                </article>
+                <article class="sales-card">
+                    <h3>Showroom by appointment</h3>
+                    <p>Eksklusiivinen showroom Herttoniemessä esittelee uusimmat mallit ja sovellukset. Varaa yksityinen demo AnomFIN-tiimin kanssa.</p>
+                    <ul>
+                        <li>Testiradat sisä- ja ulkotiloissa</li>
+                        <li>Runko- ja akkukustomoinnit</li>
+                        <li>Sähköinen tilausprosessi</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="section" id="paketit" data-reveal>
             <div class="section__intro">
                 <span class="kicker">Huoltopaketit</span>
                 <h2>Suunnitellut kokonaisuudet sähköpyörien ylläpitoon</h2>
@@ -123,45 +212,45 @@
             </div>
             <div class="grid grid--3">
                 <article class="product">
-                    <img src="https://images.unsplash.com/photo-1485965120420-1ea49c4905c7?auto=format&fit=crop&w=1200&q=80" alt="Huoltopisteessä nosturilla oleva sähköpyörä" loading="lazy">
+                    <img src="assets/ebike_web.png" alt="Huolellisesti huollettu sähköpyörä nosturilla" loading="lazy">
                     <div class="product__body">
-                        <h3>Perushuolto</h3>
-                        <p>Kauden aloitukseen tai lopetukseen. Sisältää täyshuollon ja akutestin.</p>
+                        <h3>Launch Care 299</h3>
+                        <p>Kauden starttipaketti, jossa tarkastetaan rungon, voimansiirron ja akun kunto. Sisältää täydellisen ohjelmistopäivityksen.</p>
                         <ul>
-                            <li>Hinta: 129 €</li>
-                            <li>Ohjelmistopäivitykset</li>
-                            <li>Jarru- ja vaihdesäädöt</li>
+                            <li>Hinta: 299 €</li>
+                            <li>AnomFIN diagnostiikka</li>
+                            <li>Jarru- ja vaihdesynkkaus</li>
                         </ul>
                     </div>
                 </article>
                 <article class="product">
-                    <img src="https://images.unsplash.com/photo-1496200186974-4293800e2c20?auto=format&fit=crop&w=1200&q=80" alt="Yrityksen sähköpyöräflotta sisätiloissa" loading="lazy">
+                    <img src="assets/ebike_web2.png" alt="Premium sähköpyörä yrityksen showroomissa" loading="lazy">
                     <div class="product__body">
-                        <h3>Premium-sopimus</h3>
-                        <p>Yrityksille ja aktiiviharrastajille, jotka tarvitsevat priorisoidun palvelun ja kuljetukset.</p>
+                        <h3>Pro Active 699</h3>
+                        <p>Suosituin pakettimme aktiivisille kuskeille ja yrityksille. Sisältää kausihuollot, nouto- ja palautuspalvelun sekä varaosapäivitykset.</p>
                         <ul>
-                            <li>Hinta: alkaen 189 €/kk</li>
-                            <li>Varaosat -10 %</li>
-                            <li>Nouto &amp; palautus Helsingin alueella</li>
+                            <li>Hinta: 699 €</li>
+                            <li>Varaosat -15 %</li>
+                            <li>Nouto &amp; palautus pääkaupunkiseudulla</li>
                         </ul>
                     </div>
                 </article>
                 <article class="product">
-                    <img src="https://images.unsplash.com/photo-1505678261036-a3fcc5e884ee?auto=format&fit=crop&w=1200&q=80" alt="Huoltoasiantuntija kiristää sähköpyörän pinnat" loading="lazy">
+                    <img src="assets/ebikewp.webp" alt="Fleet-huollon asiantuntija tarkastaa premium-sähköpyörää" loading="lazy">
                     <div class="product__body">
-                        <h3>Fleet Care 360</h3>
-                        <p>Laaja sopimus logistiikkayrityksille ja jakeluflotteille. Sisältää proaktiivisen kunnossapidon.</p>
+                        <h3>Fleet Signature 1499</h3>
+                        <p>Laajin palvelumme logistiikkaoperaattoreille ja luksuspyöriä käyttävälle kalustolle. Valvomme akkuja 24/7 ja toimitamme varapyörät tunneissa.</p>
                         <ul>
-                            <li>Hinta: räätälöidään</li>
-                            <li>24/7 tukilinja</li>
-                            <li>Kuukausittaiset raportit</li>
+                            <li>Hinta: 1 499 €</li>
+                            <li>24/7 ensivastehuolto</li>
+                            <li>Kokonaisraportointi ja CO₂-seuranta</li>
                         </ul>
                     </div>
                 </article>
             </div>
         </section>
 
-        <section class="section section--store" id="verkkokauppa">
+        <section class="section section--store" id="verkkokauppa" data-reveal>
             <div class="section__intro">
                 <span class="kicker">Verkkokauppa</span>
                 <h2>Upea ja sulava ostokokemus sähköpyörille ja varusteille</h2>
@@ -177,7 +266,7 @@
                         <strong data-cart-total>0,00 €</strong>
                     </div>
                     <p class="store__cart-note">Viimeistele tilauksesi lähettämällä ostoskori ja yhteystietosi asiantuntijallemme.</p>
-                    <a class="btn btn--primary" href="#yhteys">Ota yhteyttä myyntiin</a>
+                    <a class="btn btn--primary" href="verkkokauppa.html">Avaa koko verkkokauppa</a>
                 </div>
                 <div class="store__grid">
                     <article class="store-card" data-product="Tenways CGO009" data-price="2599">
@@ -256,7 +345,7 @@
             </div>
         </section>
 
-        <section class="section" id="referenssit">
+        <section class="section" id="referenssit" data-reveal>
             <div class="section__intro">
                 <span class="kicker">Asiakastarinat</span>
                 <h2>Palvelemme yrityksiä, yhteisöjä ja intohimoisia sähköpyöräilijöitä</h2>
@@ -287,7 +376,7 @@
             </div>
         </section>
 
-        <section class="section section--accent" id="laskuri">
+        <section class="section section--accent" id="laskuri" data-reveal>
             <div class="section__intro">
                 <span class="kicker kicker--light">Työkalut</span>
                 <h2>AnomFIN Huoltosäästölaskuri</h2>
@@ -323,7 +412,7 @@
             <p class="calculator__signature" aria-label="Laskelman tuottaja">AnomFIN • AnomTools</p>
         </section>
 
-        <section class="section section--accent" aria-label="Nopeat faktat Harjun Raskaskone Oy:stä">
+        <section class="section section--accent" aria-label="Nopeat faktat Harjun Raskaskone Oy:stä" data-reveal>
             <div class="facts">
                 <div>
                     <h3>Virallinen nimi</h3>
@@ -372,7 +461,7 @@
             </div>
         </section>
 
-        <section class="section section--light" id="yhteys">
+        <section class="section section--light" id="yhteys" data-reveal>
             <div class="contact">
                 <div class="contact__info">
                     <span class="kicker">Ota yhteyttä</span>
@@ -433,7 +522,7 @@
                 <ul>
                     <li><a href="#palvelut">Sähköpyörähuolto</a></li>
                     <li><a href="#paketit">Huoltopaketit</a></li>
-                    <li><a href="#verkkokauppa">Verkkokauppa</a></li>
+                    <li><a href="verkkokauppa.html">Verkkokauppa</a></li>
                 </ul>
             </div>
             <div>

--- a/verkkokauppa.html
+++ b/verkkokauppa.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Verkkokauppa • Helsinki eBike-Service Oy</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="is-preload">
+    <header class="hero" id="etusivu" data-reveal>
+        <nav class="nav">
+            <div class="nav__logo">Helsinki eBike-Service Oy</div>
+            <button class="nav__toggle" type="button" aria-label="Avaa valikko" aria-controls="nav-menu" aria-expanded="false">
+                <span></span>
+                <span></span>
+                <span></span>
+            </button>
+            <ul class="nav__links" id="nav-menu">
+                <li><a class="nav__link" href="#pyorat" data-scroll="pyorat">Sähköpyörät</a></li>
+                <li><a class="nav__link" href="#varusteet" data-scroll="varusteet">Varusteet</a></li>
+                <li><a class="nav__link" href="#paketit" data-scroll="paketit">Huoltopaketit</a></li>
+                <li><a class="nav__link" href="#yhteys" data-scroll="yhteys">Yhteys</a></li>
+                <li class="nav__cart">
+                    <a class="nav__link nav__link--cart" href="index.html" aria-label="Palaa pääsivulle">
+                        <span>Takaisin</span>
+                        <span class="nav__cart-count" aria-hidden="true">⇠</span>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+        <div class="hero__content">
+            <span class="hero__badge">Signature Experience • AnomFIN</span>
+            <p class="hero__eyebrow">Verkkokauppa yritys- ja premium-sähköpyörille</p>
+            <h1>AnomFIN eBike Boutique tarjoaa kuratoidut mallit ja elinkaaripalvelut</h1>
+            <p class="hero__lead">Jokainen verkkokaupan tuote on testattu ja dokumentoitu Jugi@AnomFIN -tiimin toimesta. Tilaa räätälöidyt paketit, jotka yhdistävät huollon, varusteet ja koulutuksen saumattomaksi kokonaisuudeksi.</p>
+            <div class="hero__actions">
+                <a class="btn btn--primary btn--xl" href="#pyorat">Katso sähköpyörät</a>
+                <a class="btn btn--store" href="index.html#yhteys">Pyydä asiantuntijaa</a>
+            </div>
+            <p class="hero__signature">Jugi@AnomFIN curated drop • Premium EV retail</p>
+        </div>
+        <div class="hero__image" data-reveal>
+            <div class="hero__panel">
+                <img src="assets/ebike_web2.png" alt="Sähköpyörä showroomissa" loading="lazy">
+                <div class="hero__panel-caption">
+                    <span>Launch Edition</span>
+                    <span>AnomFIN Boutique</span>
+                </div>
+            </div>
+            <a class="hero__elevator" href="#yhteys" aria-label="Varaa verkkokaupan demo" data-floating-origin>
+                <span class="hero__elevator-glow"></span>
+                <span class="hero__elevator-text">VARAA<br><strong>LIVE-DEMO</strong></span>
+                <span class="hero__elevator-tag">Vain ajanvarauksella</span>
+            </a>
+        </div>
+    </header>
+
+    <a class="floating-cta" href="#yhteys" data-floating-cta>
+        <span class="floating-cta__pulse" aria-hidden="true"></span>
+        <span class="floating-cta__label">AnomFIN Concierge</span>
+        <span class="floating-cta__title">Chattaa myyjän kanssa</span>
+        <span class="floating-cta__signature">Premium sähköpyörävalinnat</span>
+    </a>
+
+    <main>
+        <section class="section section--light" id="pyorat" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Sähköpyörät</span>
+                <h2>Kuratoitu mallisto kaupunkien ja logistiikan tarpeisiin</h2>
+                <p>Kaikki mallimme ovat saatavilla nopealla toimituksella sekä leasing- että yritysostoihin. Jokainen toimitus sisältää AnomFIN-käyttöönoton ja elinkaariseurannan.</p>
+            </div>
+            <div class="store__grid">
+                <article class="store-card" data-product="Tenways CGO One" data-price="2899">
+                    <img src="https://images.unsplash.com/photo-1529429617124-aee711a0fb7c?auto=format&fit=crop&w=1200&q=80" alt="Tyylikäs sähköpyörä showroomissa" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Urban</span>
+                        <h3>Tenways CGO One</h3>
+                        <p>Kevyt hiilikuiturunko, hihnaveto ja 90 km kantama. Sisältää AnomFIN Launch Care 299 -palvelun.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">2 899 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+                <article class="store-card" data-product="Tern GSD Performance" data-price="5490">
+                    <img src="https://images.unsplash.com/photo-1502877338535-766e1452684a?auto=format&fit=crop&w=1200&q=80" alt="Tavarasähköpyörä ulkona" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Cargo</span>
+                        <h3>Tern GSD Performance</h3>
+                        <p>Yritystason jakelupyörä kaksoisakkujärjestelmällä. Mukana Fleet Signature 1499 -sopimus.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">5 490 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+                <article class="store-card" data-product="Specialized Turbo Como" data-price="3990">
+                    <img src="https://images.unsplash.com/photo-1523419409543-0c1df022bdd9?auto=format&fit=crop&w=1200&q=80" alt="Design-sähköpyörä kaupunkimaisemassa" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Comfort</span>
+                        <h3>Specialized Turbo Como</h3>
+                        <p>Älykäs näytöllinen ajotuki, sisäinen johdotus ja integroidut valot. Premium Pro Active 699 -huoltotaso.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">3 990 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+                <article class="store-card" data-product="VanMoof S5" data-price="3690">
+                    <img src="https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=1200&q=80" alt="VanMoof sähköpyörä" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Design</span>
+                        <h3>VanMoof S5</h3>
+                        <p>Integroitu varashälytin ja automaattinen vaihteisto. Sisältää kaksi vuoden AnomFIN-takuun.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">3 690 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section" id="varusteet" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Varusteet</span>
+                <h2>Huippuluokan varusteet turvalliseen ajoon</h2>
+                <p>Kypärät, valaisimet ja latausratkaisut, jotka täydentävät sähköpyöräkokonaisuuden. Kaikki varusteet ovat yhteensopivia yllä mainittujen mallien kanssa.</p>
+            </div>
+            <div class="store__grid">
+                <article class="store-card" data-product="Giro Manifest" data-price="289">
+                    <img src="https://images.unsplash.com/photo-1505678261036-a3fcc5e884ee?auto=format&fit=crop&w=1200&q=80" alt="Giro Manifest kypärä" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Turvallisuus</span>
+                        <h3>Giro Manifest Spherical</h3>
+                        <p>MIPS-suojaus, säädettävä ilmanvaihto ja integroitu älyvalo. Sisältää sovituksen showroomissa.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">289 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+                <article class="store-card" data-product="Bosch PowerTube" data-price="799">
+                    <img src="https://images.unsplash.com/photo-1509395176047-4a66953fd231?auto=format&fit=crop&w=1200&q=80" alt="Bosch PowerTube akku" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Varaosat</span>
+                        <h3>Bosch PowerTube 625</h3>
+                        <p>Tehokas lisäakku Bosch Performance Line -järjestelmään. Asennus ja diagnostiikka sisältyvät.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">799 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+                <article class="store-card" data-product="Supernova E3 Pro" data-price="349">
+                    <img src="https://images.unsplash.com/photo-1604272011436-1d760c6fc1d8?auto=format&fit=crop&w=1200&q=80" alt="Supernova valosarja" loading="lazy">
+                    <div class="store-card__body">
+                        <span class="store-card__tag">Valot</span>
+                        <h3>Supernova E3 Pro</h3>
+                        <p>Äärimmäisen kirkas valosarja kaupunki- ja maantieajoihin. Sisältää asennuksen AnomFIN-huollossa.</p>
+                        <div class="store-card__footer">
+                            <span class="store-card__price">349 €</span>
+                            <button class="btn btn--secondary" type="button" data-add-to-cart>Lisää koriin</button>
+                        </div>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--light" id="paketit" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Huoltopaketit</span>
+                <h2>Kolme tasoa sähköpyöräsi täydelliseen ylläpitoon</h2>
+                <p>Valitse huoltopaketti verkkokaupan tilauksen yhteydessä. Paketit voidaan yhdistää kaikkiin malleihin ja varusteisiin.</p>
+            </div>
+            <div class="grid grid--3">
+                <article class="product">
+                    <img src="assets/ebike_web.png" alt="Huoltoasiantuntija säätää sähköpyörää" loading="lazy">
+                    <div class="product__body">
+                        <h3>Launch Care 299</h3>
+                        <p>Perushuolto ja ohjelmistopäivitykset uuden sähköpyörän luovutuksen yhteydessä.</p>
+                        <ul>
+                            <li>299 € kertamaksu</li>
+                            <li>Täydellinen turvatarkastus</li>
+                            <li>Akun kapasiteettiraportti</li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="product">
+                    <img src="assets/ebike_web2.png" alt="Premium sähköpyörä huollossa" loading="lazy">
+                    <div class="product__body">
+                        <h3>Pro Active 699</h3>
+                        <p>Kausihuollot, noutopalvelu ja priorisoitu tuki yrityskäyttöön ja aktiiviharrastajille.</p>
+                        <ul>
+                            <li>699 € vuosimaksu</li>
+                            <li>Varaosat -15 %</li>
+                            <li>24h vasteaika</li>
+                        </ul>
+                    </div>
+                </article>
+                <article class="product">
+                    <img src="assets/ebikewp.webp" alt="Fleet-huolto työpajassa" loading="lazy">
+                    <div class="product__body">
+                        <h3>Fleet Signature 1499</h3>
+                        <p>Laajin palvelu logistisiin flotteihin. Sisältää etävalvonnan, varapyörät ja kuukausiraportoinnin.</p>
+                        <ul>
+                            <li>1 499 € vuosimaksu</li>
+                            <li>Varapyöräpooli</li>
+                            <li>CO₂-seurantadata</li>
+                        </ul>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section" id="yhteys" data-reveal>
+            <div class="section__intro">
+                <span class="kicker">Ota yhteyttä</span>
+                <h2>Henkilökohtainen ostokokemus alkaa yhdestä viestistä</h2>
+                <p>Jätä meille yhteystietosi ja kerro, mikä sähköpyörä kiinnostaa. AnomFIN Concierge räätälöi tarjouksen ja aikataulun.</p>
+            </div>
+            <div class="contact">
+                <div class="contact__info">
+                    <h3>Palvelutiimi</h3>
+                    <p>Helsinki eBike-Service Oy • Jugi@AnomFIN</p>
+                    <ul class="contact__details">
+                        <li><strong>Puhelin:</strong> <a href="tel:+358403255131">040 325 5131</a></li>
+                        <li><strong>Sähköposti:</strong> <a href="mailto:verkkokauppa@helsinkiebikeservice.fi">verkkokauppa@helsinkiebikeservice.fi</a></li>
+                        <li><strong>Showroom:</strong> Herttoniemi, Helsinki</li>
+                    </ul>
+                    <div class="contact__cta">
+                        <a class="btn btn--primary" href="mailto:verkkokauppa@helsinkiebikeservice.fi">Varaa konsultaatio</a>
+                        <a class="btn btn--ghost" href="index.html#etusivu">Takaisin etusivulle</a>
+                    </div>
+                </div>
+                <form class="contact__form">
+                    <h3>Ostajan brief</h3>
+                    <label>
+                        Nimi
+                        <input type="text" name="nimi" placeholder="Yritys / Yhteyshenkilö" required>
+                    </label>
+                    <label>
+                        Sähköposti
+                        <input type="email" name="email" placeholder="sinä@yritys.fi" required>
+                    </label>
+                    <label>
+                        Valitse kiinnostava malli
+                        <input type="text" name="malli" placeholder="Esim. Tenways CGO One">
+                    </label>
+                    <label>
+                        Viesti
+                        <textarea name="viesti" rows="4" placeholder="Kerro toimitustarpeesta, aikataulusta ja huoltopaketista" required></textarea>
+                    </label>
+                    <button type="submit" class="btn btn--primary">Lähetä viesti</button>
+                    <p class="contact__disclaimer">Tallennamme tietosi tilausprosessia varten. Tervetuloa AnomFIN-asiakkaaksi!</p>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer__branding">
+            <span class="footer__logo">Helsinki eBike-Service Oy</span>
+            <p>Sähköpyörien huolto, myynti ja verkkokauppa. AnomFIN curated kokemukset yrityksille ja harrastajille.</p>
+        </div>
+        <div class="footer__links">
+            <div>
+                <h4>Verkkokauppa</h4>
+                <ul>
+                    <li><a href="#pyorat">Sähköpyörät</a></li>
+                    <li><a href="#varusteet">Varusteet</a></li>
+                    <li><a href="#paketit">Huoltopaketit</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4>Palvelut</h4>
+                <ul>
+                    <li><a href="index.html#palvelut">Huolto ja korjaukset</a></li>
+                    <li><a href="index.html#vuokraus">Vuokraus</a></li>
+                    <li><a href="index.html#myynti">Myynti &amp; hankinta</a></li>
+                </ul>
+            </div>
+            <div>
+                <h4>Yhteystiedot</h4>
+                <ul>
+                    <li><a href="tel:+358403255131">040 325 5131</a></li>
+                    <li><a href="mailto:verkkokauppa@helsinkiebikeservice.fi">verkkokauppa@helsinkiebikeservice.fi</a></li>
+                    <li>Aarteenetsijäntie 4, 00970 Helsinki</li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer__meta">
+            <span>AnomFIN • Verkkokauppa</span>
+            <span>© <span id="year"></span> Helsinki eBike-Service Oy</span>
+        </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce coordinated fade-in animations, floating ecommerce CTA, and active navigation states on the landing page
- refresh service imagery and copy, enlarge the “Tutustu verkkokauppaan” action, and update maintenance packages with new pricing
- add a dedicated `verkkokauppa.html` storefront featuring curated products, accessories, and contact flow

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68ec3df2d37c8332bd307dee22c0af08